### PR TITLE
Make HTTP server host/port configurable

### DIFF
--- a/docs/plugins/listening.rst
+++ b/docs/plugins/listening.rst
@@ -203,6 +203,22 @@ of the server backend you want in your settings as ``HTTP_SERVER_BACKEND``.
 If you don't need this functionality, you can disable the HTTP server by setting ``DISABLE_HTTP``
 to ``True`` in your settings.
 
+The built-in HTTP server which can be configured using the following settings:
+
+.. code-block:: python
+
+    # Should the HTTP server be enabled?
+    DISABLE_HTTP = False
+
+    # Which serving backend should `bottle` use?
+    HTTP_SERVER_BACKEND = 'wsgiref'
+
+    # Host address to listen on
+    HTTP_SERVER_HOST = '0.0.0.0'
+
+    # Host port to listen on
+    HTTP_SERVER_PORT = 8080
+
 .. _Bottle: https://bottlepy.org
 .. _Bottle route(): https://bottlepy.org/docs/0.12/api.html#bottle.route
 .. _Bottle supports: https://bottlepy.org/docs/0.12/deployment.html#switching-the-server-backend

--- a/docs/user/usage.rst
+++ b/docs/user/usage.rst
@@ -118,3 +118,27 @@ instance running on *localhost* on the default port, you would add this to your 
 .. _Redis: https://redis.io/
 
 That's all there is to it!
+
+HTTP Server
+"""""""""""
+
+Slack Machine has a built-in HTTP server which can be configured using the following settings:
+
+.. code-block:: python
+
+    # Should the HTTP server be enabled?
+    DISABLE_HTTP = False
+
+    # Which serving backend should `bottle` use?
+    HTTP_SERVER_BACKEND = 'wsgiref'
+
+    # Host address to listen on
+    HTTP_SERVER_HOST = '0.0.0.0'
+
+    # Host port to listen on
+    HTTP_SERVER_PORT = 8080
+
+
+For more information about possible values for ``HTTP_SERVER_BACKEND``, check out the `Bottle Server Backends`_ documentation.
+
+.. _Bottle Server Backends: https://bottlepy.org/docs/0.12/deployment.html#switching-the-server-backend

--- a/docs/user/usage.rst
+++ b/docs/user/usage.rst
@@ -118,27 +118,3 @@ instance running on *localhost* on the default port, you would add this to your 
 .. _Redis: https://redis.io/
 
 That's all there is to it!
-
-HTTP Server
-"""""""""""
-
-Slack Machine has a built-in HTTP server which can be configured using the following settings:
-
-.. code-block:: python
-
-    # Should the HTTP server be enabled?
-    DISABLE_HTTP = False
-
-    # Which serving backend should `bottle` use?
-    HTTP_SERVER_BACKEND = 'wsgiref'
-
-    # Host address to listen on
-    HTTP_SERVER_HOST = '0.0.0.0'
-
-    # Host port to listen on
-    HTTP_SERVER_PORT = 8080
-
-
-For more information about possible values for ``HTTP_SERVER_BACKEND``, check out the `Bottle Server Backends`_ documentation.
-
-.. _Bottle Server Backends: https://bottlepy.org/docs/0.12/deployment.html#switching-the-server-backend

--- a/machine/__about__.py
+++ b/machine/__about__.py
@@ -7,7 +7,7 @@ __title__ = "slack-machine"
 __description__ = "A sexy, simple, yet powerful and extendable Slack bot"
 __uri__ = "https://github.com/DandyDev/slack-machine"
 
-__version_info__ = (0, 13, 1)
+__version_info__ = (0, 13, 2)
 __version__ = '.'.join(map(str, __version_info__))
 
 __author__ = "Daan Debie"

--- a/machine/core.py
+++ b/machine/core.py
@@ -188,8 +188,11 @@ class Machine:
             if not self._settings['DISABLE_HTTP']:
                 self._bottle_thread = Thread(
                     target=bottle.run,
-                    kwargs=dict(host='0.0.0.0', port=8080,
-                                server=self._settings['HTTP_SERVER_BACKEND'])
+                    kwargs=dict(
+                        host=self._settings['HTTP_SERVER_HOST'],
+                        port=self._settings['HTTP_SERVER_PORT'],
+                        server=self._settings['HTTP_SERVER_BACKEND'],
+                    )
                 )
                 self._bottle_thread.daemon = True
                 self._bottle_thread.start()

--- a/machine/settings.py
+++ b/machine/settings.py
@@ -14,7 +14,9 @@ def import_settings(settings_module='local_settings'):
                     'machine.plugins.builtin.fun.memes.MemePlugin'],
         'STORAGE_BACKEND': 'machine.storage.backends.memory.MemoryStorage',
         'DISABLE_HTTP': False,
-        'HTTP_SERVER_BACKEND': 'wsgiref'
+        'HTTP_SERVER_HOST': '0.0.0.0',
+        'HTTP_SERVER_PORT': 8080,
+        'HTTP_SERVER_BACKEND': 'wsgiref',
     }
     settings = CaseInsensitiveDict(default_settings)
     try:


### PR DESCRIPTION
This adds two new settings for configuring the HTTP server:
- `HTTP_SERVER_HOST`
- `HTTP_SERVER_PORT`

Also, includes configuration documentation for the HTTP server :smile: