### PR TITLE
core: Add suport for keepalive messages

### DIFF
--- a/docs/user/usage.rst
+++ b/docs/user/usage.rst
@@ -30,6 +30,9 @@ You can override the log level by setting ``LOGLEVEL``. By default this is set t
 If you want to use Slack Machine behind a proxy, you can use ``HTTP_PROXY`` and ``HTTPS_PROXY``.
 Be cautious, only http proxy is supported for now.
 
+If you find you have issues with Slack Machine disconnecting, try enabling the keep alive
+feature by setting ``KEEP_ALIVE`` to an integer (interval in seconds to send keep alive pings).
+
 
 Enabling plugins
 """"""""""""""""

--- a/machine/dispatch.py
+++ b/machine/dispatch.py
@@ -42,6 +42,8 @@ class EventDispatcher:
             else:
                 listeners = self._find_listeners('listen_to')
                 self._dispatch_listeners(listeners, event)
+        if 'type' in event and event['type'] == 'pong':
+            logger.debug("Server Pong!")
 
     def _find_listeners(self, type):
         return [action for action in self._plugin_actions[type].values()]


### PR DESCRIPTION
 * This patch is in response to https://github.com/DandyDev/slack-machine/issues/54

   The websocket connection in slackclient seems to be getting dropped from the
   server side, with little to no indication as to why. Slack supports a ping/pong
   keep alive, and this implements it with slack machine.