### PR TITLE
Add `is_thread` method to class Message

### DIFF
--- a/machine/plugins/base.py
+++ b/machine/plugins/base.py
@@ -549,6 +549,7 @@ class Message:
 
         return thread_ts
 
+    @property
     def in_thread(self):
         """Is message in a thread
 

--- a/machine/plugins/base.py
+++ b/machine/plugins/base.py
@@ -549,6 +549,13 @@ class Message:
 
         return thread_ts
 
+    def in_thread(self):
+        """Is message in a thread
+
+        :return: bool
+        """
+        return 'thread_ts' in self._msg_event
+
     def __str__(self):
         return "Message '{}', sent by user @{} in channel #{}".format(
             self.text,


### PR DESCRIPTION
Added method to determine if a given message is part of a thread or not.

Use full if you only want to respond to "channel messages", or if you want to respond "in thread" if asked "in thread".