### PR TITLE
Add RBAC decorator and plugin

### DIFF
--- a/docs/plugins/interacting.rst
+++ b/docs/plugins/interacting.rst
@@ -186,7 +186,7 @@ If you wish to share the powers of root you can enable the RBAC admin plugin
 to users you trust.
 
 The RBAC plugin provides you with three new commands that lets you lookup, grant
-and revoke roles to users: *@superbot who has role admin*, *@superbot grant
+and revoke roles to users: *@superbot who has role admin*, *@superbot grant role
 admin to @trusted_user*, *@superbot revoke role admin from @trusted_user*.
 
 Her is an example of a command that requires either the *admin* or *channel*

--- a/docs/plugins/interacting.rst
+++ b/docs/plugins/interacting.rst
@@ -155,6 +155,58 @@ There is one caveat:
 
 For more information about scheduling message, have a look at the :ref:`api documentation`.
 
+.. _protecting-messages:
+
+Protecting messages
+-------------------
+
+Sometimes you may want to restrict your bot, so it will only react to certain
+users.
+
+To use these restrictions you must appoint one user to be *root*. For security
+reasons there can be only one *root* user, and it must be configured
+``local_settings.py``. That way you will never loose control over your bot.
+
+To enable all the role based features, your ``local_settings.py`` would look
+something like this:
+
+.. code-block:: python
+
+    SLACK_API_TOKEN = 'xoxb-my-slack-token'
+    RBAC_ROLE_ROOT = 'U0000007'
+    PLUGINS = [
+        'machine.plugins.builtin.admin.RBACPlugin',
+    ]
+
+You can get the *member ID* from the slack profile, by clicking *more* and
+selecting *Copy member ID*.
+
+If you wish to share the powers of root you can enable the RBAC admin plugin
+:py:class:`~machine.plugins.builtin.admin.RBACPlugin` and grant the *admin* role
+to users you trust.
+
+The RBAC plugin provides you with three new commands that lets you lookup, grant
+and revoke roles to users: *@superbot who has role admin*, *@superbot grant
+admin to @trusted_user*, *@superbot revoke role admin from @trusted_user*.
+
+Her is an example of a command that requires either the *admin* or *channel*
+role:
+
+.. code-block:: python
+
+    @respond_to(
+        r"^say in"
+        r'\s+<#\w+\|(?P<channel_name>[^>]+)>'
+        r'\s+(?P<message>.+)'
+    )
+    @require_any_role(['admin', 'channel'])
+    def say_in_channel(self, msg, channel_name, message):
+        logging.info(channel_name)
+        self.say(channel_name, message)
+
+You can define as many roles as you want, any string without spaces is
+acceptable.
+
 .. _emitting-events:
 
 Emitting events

--- a/machine/core.py
+++ b/machine/core.py
@@ -135,7 +135,7 @@ class Machine:
             if action == 'process':
                 event_type = config['event_type']
                 RTMClient.on(event=event_type, callback=callable_with_sanitized_event(fn))
-            if action == 'respond_to' or action == 'listen_to':
+            if action in ['respond_to', 'listen_to']:
                 for regex in config['regex']:
                     event_handler = {
                         'class': cls_instance,

--- a/machine/plugins/builtin/admin.py
+++ b/machine/plugins/builtin/admin.py
@@ -1,0 +1,80 @@
+import logging
+from machine.plugins.base import MachineBasePlugin
+from machine.plugins.decorators import respond_to, required_settings, rbac_require_any_role
+
+logger = logging.getLogger(__name__)
+
+
+def role_assignments_by_role(self, role):
+    roles = self.storage.get(f'rbac:role:{role}', shared=True)
+    roles = roles if roles else {}
+    if role == 'root':
+        roles = {
+            self.settings['RBAC_ROLE_ROOT']: 1
+        }
+    return roles
+
+
+def matching_roles_by_user_id(self, user_id, roles):
+    matching_roles = 0
+    for role in roles:
+        assigned_roles = role_assignments_by_role(self, role)
+        if assigned_roles and user_id in assigned_roles:
+            matching_roles = matching_roles + 1
+
+    return matching_roles
+
+
+def notify_admins(self, title, message, icon='warning', color='#ff0000'):
+    roots  = role_assignments_by_role(self, 'root')
+    admins = role_assignments_by_role(self, 'admin')
+
+    admins_to_be_notified = {**admins, **roots}
+    for user_id in admins_to_be_notified:
+        self.send_dm(
+            user_id, f':{icon}: *{title}*', attachments=[{
+                "color": color,
+                "text": message
+            }]
+        )
+
+
+@required_settings(['RBAC_ROLE_ROOT'])
+class RBACPlugin(MachineBasePlugin):
+    """Role based access control"""
+
+    @respond_to(regex=r'^grant\s+role\s+(?P<role>\w+)\s+to\s+<@(?P<user_id>\w+)>$')
+    @rbac_require_any_role(['root', 'admin'])
+    def grant_role_to_user(self, msg, role, user_id):
+        """grant role <role> to @user"""
+        if role == 'root':
+            msg.say("Sorry, role `root` can only be granted via static configuration")
+            return
+        roles = role_assignments_by_role(self, role)
+        roles[user_id] = 1
+        self.storage.set(f'rbac:role:{role}', roles, shared=True)
+        msg.say(f'Role `{role}` has been granted to <@{user_id}>')
+
+    @respond_to(regex=r'^revoke\s+role\s+(?P<role>\w+)\s+from\s+<@(?P<user_id>\w+)>$')
+    @rbac_require_any_role(['root', 'admin'])
+    def revoke_role_from_user(self, msg, role, user_id):
+        """revoke role <role> from @user"""
+        assigned_roles = role_assignments_by_role(self, role)
+        if user_id in assigned_roles:
+            del assigned_roles[user_id]
+            self.storage.set(f'rbac:role:{role}', assigned_roles, shared=True)
+            msg.say(f'Role `{role}` has been revoked from <@{user_id}>')
+        else:
+            msg.say(f'Role <@{user_id}> does not have role `{role}`')
+
+    @respond_to(regex=r'^who\s+has\s+role\s+(?P<role>\w+)')
+    @rbac_require_any_role(['root', 'admin'])
+    def who_has_role(self, msg, role):
+        """who has role <role>"""
+        assigned_roles = role_assignments_by_role(self, role)
+        if len(assigned_roles):
+            msg.say(
+                f'Role `{role}` has been granted to {", ".join([f"<@{user_id}>" for user_id in assigned_roles.keys()])}'
+            )
+        else:
+            msg.say(f'No one have been assigned role `{role}`')

--- a/machine/plugins/builtin/admin.py
+++ b/machine/plugins/builtin/admin.py
@@ -7,7 +7,7 @@ logger = logging.getLogger(__name__)
 
 def role_assignments_by_role(self, role):
     roles = self.storage.get(f'rbac:role:{role}', shared=True)
-    roles = roles if roles else {}
+    roles = roles or {}
     if role == 'root':
         roles = {
             self.settings['RBAC_ROLE_ROOT']: 1

--- a/machine/plugins/builtin/admin.py
+++ b/machine/plugins/builtin/admin.py
@@ -46,7 +46,7 @@ class RBACPlugin(MachineBasePlugin):
     @respond_to(regex=r'^grant\s+role\s+(?P<role>\w+)\s+to\s+<@(?P<user_id>\w+)>$')
     @require_any_role(['root', 'admin'])
     def grant_role_to_user(self, msg, role, user_id):
-        """grant role <role> to @user"""
+        """grant role <role> to <user>: Grant role"""
         if role == 'root':
             msg.say("Sorry, role `root` can only be granted via static configuration")
             return
@@ -58,7 +58,7 @@ class RBACPlugin(MachineBasePlugin):
     @respond_to(regex=r'^revoke\s+role\s+(?P<role>\w+)\s+from\s+<@(?P<user_id>\w+)>$')
     @require_any_role(['root', 'admin'])
     def revoke_role_from_user(self, msg, role, user_id):
-        """revoke role <role> from @user"""
+        """revoke role <role> from <user>: Revoke role"""
         assigned_roles = role_assignments_by_role(self, role)
         if user_id in assigned_roles:
             del assigned_roles[user_id]
@@ -70,7 +70,7 @@ class RBACPlugin(MachineBasePlugin):
     @respond_to(regex=r'^who\s+has\s+role\s+(?P<role>\w+)')
     @require_any_role(['root', 'admin'])
     def who_has_role(self, msg, role):
-        """who has role <role>"""
+        """who has role <role>: List users with role"""
         assigned_roles = role_assignments_by_role(self, role)
         if len(assigned_roles):
             msg.say(

--- a/machine/plugins/builtin/admin.py
+++ b/machine/plugins/builtin/admin.py
@@ -1,6 +1,6 @@
 import logging
 from machine.plugins.base import MachineBasePlugin
-from machine.plugins.decorators import respond_to, required_settings, rbac_require_any_role
+from machine.plugins.decorators import respond_to, required_settings, require_any_role
 
 logger = logging.getLogger(__name__)
 
@@ -44,7 +44,7 @@ class RBACPlugin(MachineBasePlugin):
     """Role based access control"""
 
     @respond_to(regex=r'^grant\s+role\s+(?P<role>\w+)\s+to\s+<@(?P<user_id>\w+)>$')
-    @rbac_require_any_role(['root', 'admin'])
+    @require_any_role(['root', 'admin'])
     def grant_role_to_user(self, msg, role, user_id):
         """grant role <role> to @user"""
         if role == 'root':
@@ -56,7 +56,7 @@ class RBACPlugin(MachineBasePlugin):
         msg.say(f'Role `{role}` has been granted to <@{user_id}>')
 
     @respond_to(regex=r'^revoke\s+role\s+(?P<role>\w+)\s+from\s+<@(?P<user_id>\w+)>$')
-    @rbac_require_any_role(['root', 'admin'])
+    @require_any_role(['root', 'admin'])
     def revoke_role_from_user(self, msg, role, user_id):
         """revoke role <role> from @user"""
         assigned_roles = role_assignments_by_role(self, role)
@@ -68,7 +68,7 @@ class RBACPlugin(MachineBasePlugin):
             msg.say(f'Role <@{user_id}> does not have role `{role}`')
 
     @respond_to(regex=r'^who\s+has\s+role\s+(?P<role>\w+)')
-    @rbac_require_any_role(['root', 'admin'])
+    @require_any_role(['root', 'admin'])
     def who_has_role(self, msg, role):
         """who has role <role>"""
         assigned_roles = role_assignments_by_role(self, role)

--- a/machine/plugins/builtin/admin.py
+++ b/machine/plugins/builtin/admin.py
@@ -20,7 +20,7 @@ def matching_roles_by_user_id(self, user_id, roles):
     for role in roles:
         assigned_roles = role_assignments_by_role(self, role)
         if assigned_roles and user_id in assigned_roles:
-            matching_roles = matching_roles + 1
+            matching_roles += 1
 
     return matching_roles
 

--- a/machine/plugins/decorators.py
+++ b/machine/plugins/decorators.py
@@ -176,7 +176,7 @@ def route(path, **kwargs):
     return route_decorator
 
 
-def rbac_require_any_role(required_roles=[]):
+def require_any_role(required_roles=[]):
     def middle(func):
         def wrapper(self, msg, **kwargs):
             if admin.matching_roles_by_user_id(self, msg.sender.id, required_roles):
@@ -197,7 +197,7 @@ def rbac_require_any_role(required_roles=[]):
     return middle
 
 
-def rbac_require_all_roles(required_roles=[]):
+def require_all_roles(required_roles=[]):
     def middle(func):
         def wrapper(self, msg, **kwargs):
             if admin.matching_roles_by_user_id(self, msg.sender.id, required_roles) == len(required_roles):

--- a/machine/plugins/decorators.py
+++ b/machine/plugins/decorators.py
@@ -200,6 +200,10 @@ def require_any_role(required_roles=[]):
                     f'```{msg.text}``` but lacks _one_ of these roles: {", ".join([f"`{role}`" for role in required_roles])}'
                 )
                 return
+        # Copy any existing docs and metadata from container function to
+        # generated function
+        wrapper.__doc__ = func.__doc__
+        wrapper.metadata = getattr(func, "metadata", {})
         return wrapper
     return middle
 
@@ -228,5 +232,9 @@ def require_all_roles(required_roles=[]):
                     f'```{msg.text}``` but lacks _all_ of these roles: {", ".join([f"`{role}`" for role in required_roles])}'
                 )
                 return
+        # Copy any existing docs and metadata from container function to
+        # generated function
+        wrapper.__doc__ = func.__doc__
+        wrapper.metadata = getattr(func, "metadata", {})
         return wrapper
     return middle

--- a/machine/plugins/decorators.py
+++ b/machine/plugins/decorators.py
@@ -199,7 +199,7 @@ def require_any_role(required_roles=[]):
                     f'User {msg.at_sender} tried to execute the following command:'
                     f'```{msg.text}``` but lacks _one_ of these roles: {", ".join([f"`{role}`" for role in required_roles])}'
                 )
-                return
+
         # Copy any existing docs and metadata from container function to
         # generated function
         wrapper.__doc__ = func.__doc__

--- a/machine/plugins/decorators.py
+++ b/machine/plugins/decorators.py
@@ -1,7 +1,7 @@
 import re
 
 from blinker import signal
-
+from machine.plugins.builtin import admin
 
 def process(slack_event_type):
     """Process Slack events of a specific type
@@ -174,3 +174,45 @@ def route(path, **kwargs):
         return f
 
     return route_decorator
+
+
+def rbac_require_any_role(required_roles=[]):
+    def middle(func):
+        def wrapper(self, msg, **kwargs):
+            if admin.matching_roles_by_user_id(self, msg.sender.id, required_roles):
+                return func(self, msg, **kwargs)
+            else:
+                msg.say(
+                    "I'm sorry, but you don't have access to that command",
+                    ephemeral=True
+                )
+                admin.notify_admins(
+                    self,
+                    f'Attempt to execute unauthorized command',
+                    f'User {msg.at_sender} tried to execute the following command:'
+                    f'```{msg.text}``` but lacks _one_ of these roles: {", ".join([f"`{role}`" for role in required_roles])}'
+                )
+                return
+        return wrapper
+    return middle
+
+
+def rbac_require_all_roles(required_roles=[]):
+    def middle(func):
+        def wrapper(self, msg, **kwargs):
+            if admin.matching_roles_by_user_id(self, msg.sender.id, required_roles) == len(required_roles):
+                return func(self, msg, **kwargs)
+            else:
+                msg.say(
+                    "I'm sorry, but you don't have access to that command",
+                    ephemeral=True
+                )
+                admin.notify_admins(
+                    self,
+                    f'Attempt to execute unauthorized command',
+                    f'User {msg.at_sender} tried to execute the following command:'
+                    f'```{msg.text}``` but lacks _all_ of these roles: {", ".join([f"`{role}`" for role in required_roles])}'
+                )
+                return
+        return wrapper
+    return middle

--- a/machine/plugins/decorators.py
+++ b/machine/plugins/decorators.py
@@ -177,6 +177,13 @@ def route(path, **kwargs):
 
 
 def require_any_role(required_roles=[]):
+    """Specify required roles for a plugin method
+
+    To use the plugin method where this decorator is applied, the user must have
+    at least one of the listed roles.
+
+    :param required_roles: list of roles required to use the plugin method
+    """
     def middle(func):
         def wrapper(self, msg, **kwargs):
             if admin.matching_roles_by_user_id(self, msg.sender.id, required_roles):
@@ -198,6 +205,13 @@ def require_any_role(required_roles=[]):
 
 
 def require_all_roles(required_roles=[]):
+    """Specify required roles for a plugin method
+
+    To use the plugin method where this decorator is applied, the user must have
+    all of the listed roles.
+
+    :param required_roles: list of roles required to use the plugin method
+    """
     def middle(func):
         def wrapper(self, msg, **kwargs):
             if admin.matching_roles_by_user_id(self, msg.sender.id, required_roles) == len(required_roles):


### PR DESCRIPTION
Role based authentication for use in plugins.

Included in this pull request is two decorators: `rbac_require_any_role` and `rbac_require_all_role`, and a "admin" plugin for assigning roles dynamically, and for being notified of people trying to use commands they aren't allowed to.

```python
# User must have any one of the listed roles
@respond_to(regex=r'^my cool command$')
@rbac_require_any_role(['root', 'admin'])
def my_cool_comand(self, msg):
    pass

# User must have all of the listed roles
@respond_to(regex=r'^my other command$')
@rbac_require_all_roles(['role1', 'role2'])
def my_other_comand(self, msg):
    pass
```

Still needs docs and better error handling for edge cases.