### PR TITLE
Replace channels_info with conversations_info

### DIFF
--- a/machine/clients/singletons/slack.py
+++ b/machine/clients/singletons/slack.py
@@ -84,7 +84,7 @@ class LowLevelSlackClient(metaclass=Singleton):
         logger.debug("User changed: %s" % user)
 
     def _on_channel_created(self, **payload):
-        channel_resp = self.web_client.channels_info(channel=payload['data']['channel']['id'])
+        channel_resp = self.web_client.conversations_info(channel=payload['data']['channel']['id'])
         channel = self._register_channel(channel_resp['channel'])
         logger.debug("Channel created: %s" % channel)
 
@@ -94,7 +94,7 @@ class LowLevelSlackClient(metaclass=Singleton):
             channel_id = data['channel']['id']
         else:
             channel_id = data['channel']
-        channel_resp = self.web_client.channels_info(channel=channel_id)
+        channel_resp = self.web_client.conversations_info(channel=channel_id)
         channel = self._register_channel(channel_resp['channel'])
         logger.debug("Channel updated: %s" % channel)
 

--- a/machine/models/user.py
+++ b/machine/models/user.py
@@ -7,19 +7,19 @@ from dacite import from_dict
 @dataclass(frozen=True)
 class Profile:
     avatar_hash: str
-    status_text: str
-    status_emoji: str
-    status_expiration: int
+    status_text: Optional[str]
+    status_emoji: Optional[str]
+    status_expiration: Optional[int]
     real_name: str
     display_name: str
     real_name_normalized: str
     display_name_normalized: str
-    image_24: str
-    image_32: str
-    image_48: str
-    image_72: str
-    image_192: str
-    image_512: str
+    image_24: Optional[str]
+    image_32: Optional[str]
+    image_48: Optional[str]
+    image_72: Optional[str]
+    image_192: Optional[str]
+    image_512: Optional[str]
     team: str
     email: Optional[str] = None
     image_original: Optional[str] = None
@@ -31,7 +31,7 @@ class User:
     User model that represents a user object from the Slack API
     """
     id: str
-    team_id: str
+    team_id: Optional[str]
     name: str
     deleted: Optional[bool]
     profile: Profile


### PR DESCRIPTION
As of slack-machine v0.20 release i am getting :- 
[2020-07-23 01:23:44][ERROR] slack.rtm.client client.py:_dispatch_event:505 | When calling '#_on_channel_created()' in the 'machine.clients.singletons.slack' module the following error was raised: The request to the Slack API failed.
The server responded with: {'ok': False, 'error': 'method_deprecated', 'response_metadata': {'messages': ['[ERROR] This method is retired and can no longer be used. Please use conversations.info instead. Learn more: https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api.']}}

This PR moves the calls from channels_info to conversations_info and makes a bunch of model fields optional that slack does not return in some cases