### PR TITLE
Passing Machine settings to LowLevelSlackClient

### DIFF
--- a/machine/clients/singletons/slack.py
+++ b/machine/clients/singletons/slack.py
@@ -26,8 +26,8 @@ def call_paginated_endpoint(endpoint: Callable, field: str, **kwargs) -> List:
 
 
 class LowLevelSlackClient(metaclass=Singleton):
-    def __init__(self):
-        _settings, _ = import_settings()
+    def __init__(self, settings=None):
+        _settings = settings
         slack_api_token = _settings.get('SLACK_API_TOKEN', None)
         http_proxy = _settings.get('HTTP_PROXY', None)
         self.rtm_client = RTMClient(token=slack_api_token, proxy=http_proxy)

--- a/machine/core.py
+++ b/machine/core.py
@@ -56,7 +56,7 @@ class Machine:
             if 'SLACK_API_TOKEN' not in self._settings:
                 error("No SLACK_API_TOKEN found in settings! I need that to work...")
                 sys.exit(1)
-            self._client = LowLevelSlackClient()
+            self._client = LowLevelSlackClient(settings=self._settings)
             puts("Initializing storage using backend: {}".format(self._settings['STORAGE_BACKEND']))
             self._storage = Storage.get_instance()
             logger.debug("Storage initialized!")

--- a/machine/dispatch.py
+++ b/machine/dispatch.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 class EventDispatcher:
 
     def __init__(self, plugin_actions, settings=None):
-        self._client = LowLevelSlackClient()
+        self._client = LowLevelSlackClient(settings=settings)
         self._plugin_actions = plugin_actions
         alias_regex = ''
         if settings and "ALIASES" in settings:


### PR DESCRIPTION
# What? 

The proposed changes to make sure the dictionary passed into Machine class is shared with the slack client. As it currently stands from quick checks the LowLevelSlackClient class reimports settings and then loses context of the passed in dictionary from the machine that includes the slack token. 


This is in response to my initial issue https://github.com/DandyDev/slack-machine/issues/390

