### PR TITLE
Updated im.open to conversations.open in machine.clients.slack.open_im(), fixed bug when bot is newly added to group chat

### DIFF
--- a/machine/clients/singletons/slack.py
+++ b/machine/clients/singletons/slack.py
@@ -111,6 +111,8 @@ class LowLevelSlackClient(metaclass=Singleton):
         RTMClient.on(event='open', callback=self._on_open)
         RTMClient.on(event='team_join', callback=self._on_team_join)
         RTMClient.on(event='channel_created', callback=self._on_channel_created)
+        RTMClient.on(event='group_joined', callback=self._on_channel_created)
+        RTMClient.on(event='mpim_joined', callback=self._on_channel_created)
         RTMClient.on(event='im_created', callback=self._on_channel_created)
         RTMClient.on(event='channel_deleted', callback=self._on_channel_deleted)
         RTMClient.on(event='im_close', callback=self._on_channel_deleted)

--- a/machine/clients/slack.py
+++ b/machine/clients/slack.py
@@ -75,7 +75,7 @@ class SlackClient:
 
     def open_im(self, user: Union[User, str]) -> str:
         user_id = id_for_user(user)
-        response = LowLevelSlackClient.get_instance().web_client.im_open(user=user_id)
+        response = LowLevelSlackClient.get_instance().web_client.conversations_open(users=user_id)
         return response['channel']['id']
 
     def send_dm(self, user: Union[User, str], text: str, **kwargs):

--- a/machine/dispatch.py
+++ b/machine/dispatch.py
@@ -39,8 +39,8 @@ class EventDispatcher:
     def handle_message(self, **payload):
         # Handle message listeners
         event = payload['data']
-        # Handle message subtypes like 'message_changed'
-        if 'subtype' in event:
+        # Handle message subtype 'message_changed' to allow the bot to respond to edits
+        if 'subtype' in event and event['subtype'] == 'message_changed':
             event = event['message']
             event['channel'] = payload['data'].get('channel', '')
         if 'user' in event and not event['user'] == self._get_bot_id():

--- a/machine/dispatch.py
+++ b/machine/dispatch.py
@@ -39,6 +39,10 @@ class EventDispatcher:
     def handle_message(self, **payload):
         # Handle message listeners
         event = payload['data']
+        # Handle message subtypes like 'message_changed'
+        if 'subtype' in event:
+            event = event['message']
+            event['channel'] = payload['data'].get('channel', '')
         if 'user' in event and not event['user'] == self._get_bot_id():
             respond_to_msg = self._check_bot_mention(event)
             if respond_to_msg:


### PR DESCRIPTION
When I tried using `machine.clients.slack.send_dm()` in my plugin like this:
```
def init(self):
  self.send_dm(user=user_id text="Some text here")
```

I got the following error:
```
2020-08-14 09:41:48][DEBUG] machine.core core.py:load_plugins:83 | Found a Machine plugin: plugins.custom.customPlugin
/home/user/.local/lib/python3.6/site-packages/slack/web/base_client.py:718: UserWarning: im.open is deprecated. Please use the Conversations API instead. For more info, go to https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
  warnings.warn(message)
[2020-08-14 09:41:48][DEBUG] slack.web.base_client base_client.py:_urllib_api_call:420 | Sending a request - url: https://www.slack.com/api/im.open, query_params: {}, body_params: {}, files: {}, json_body: {'user': '<user_id>'}, headers: {'User-Agent': 'Python/3.6.9 slackclient/2.7.3 Linux/5.4.0-42-generic', 'Content-Type': 'application/json;charset=utf-8', 'Authorization': '(redacted)'}
[2020-08-14 09:41:53][DEBUG] slack.web.slack_response slack_response.py:validate:187 | Received the following response - status: 200, headers: {'date': 'Fri, 14 Aug 2020 13:41:53 GMT', 'server': 'Apache', 'expires': 'Mon, 26 Jul 1997 05:00:00 GMT', 'x-content-type-options': 'nosniff', 'x-slack-req-id': '<redacted>', 'cache-control': 'private, no-cache, no-store, must-revalidate', 'x-oauth-scopes': 'identify,read,post,client,apps', 'x-xss-protection': '0', 'pragma': 'no-cache', 'vary': 'Accept-Encoding', 'access-control-allow-headers': 'slack-route, x-slack-version-ts, x-b3-traceid, x-b3-spanid, x-b3-parentspanid, x-b3-sampled, x-b3-flags', 'strict-transport-security': 'max-age=31536000; includeSubDomains; preload', 'referrer-policy': 'no-referrer', 'x-slack-backend': 'r', 'access-control-expose-headers': 'x-slack-req-id, retry-after', 'access-control-allow-origin': '*', 'connection': 'close', 'transfer-encoding': 'chunked', 'content-type': 'application/json; charset=utf-8', 'x-via': '<redacted>'}, body: {'ok': False, 'error': 'method_deprecated', 'response_metadata': {'messages': ['[ERROR] This method is retired and can no longer be used. Please use conversations.open instead. Learn more: https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api.']}}
Traceback (most recent call last):
  File "/home/user/.local/bin/slack-machine", line 11, in <module>
    sys.exit(main())
  File "/home/user/.local/lib/python3.6/site-packages/machine/bin/run.py", line 12, in main
    bot = Machine()
  File "/home/user/.local/lib/python3.6/site-packages/machine/core.py", line 74, in __init__
    self.load_plugins()
  File "/home/user/.local/lib/python3.6/site-packages/machine/core.py", line 97, in load_plugins
    instance.init()
  File "/home/user/custom-slackbot/slackbot-docker/slackbot/plugins/custom.py", line 19, in init
    self.send_dm(user="<user_id>", text="custom Slackbot started!")
  File "/home/user/.local/lib/python3.6/site-packages/machine/plugins/base.py", line 207, in send_dm
    return self._client.send_dm(user, text, attachments=attachments, blocks=blocks, **kwargs)
  File "/home/user/.local/lib/python3.6/site-packages/machine/clients/slack.py", line 83, in send_dm
    dm_channel_id = self.open_im(user_id)
  File "/home/user/.local/lib/python3.6/site-packages/machine/clients/slack.py", line 78, in open_im
    response = LowLevelSlackClient.get_instance().web_client.im_open(user=user_id)
  File "/home/user/.local/lib/python3.6/site-packages/slack/web/client.py", line 1502, in im_open
    return self.api_call("im.open", json=kwargs)
  File "/home/user/.local/lib/python3.6/site-packages/slack/web/base_client.py", line 215, in api_call
    return self._sync_send(api_url=api_url, req_args=req_args)
  File "/home/user/.local/lib/python3.6/site-packages/slack/web/base_client.py", line 357, in _sync_send
    additional_headers=headers,
  File "/home/user/.local/lib/python3.6/site-packages/slack/web/base_client.py", line 486, in _urllib_api_call
    use_sync_aiohttp=False,
  File "/home/user/.local/lib/python3.6/site-packages/slack/web/slack_response.py", line 195, in validate
    raise e.SlackApiError(message=msg, response=self)
slack.errors.SlackApiError: The request to the Slack API failed.
The server responded with: {'ok': False, 'error': 'method_deprecated', 'response_metadata': {'messages': ['[ERROR] This method is retired and can no longer be used. Please use conversations.open instead. Learn more: https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api.']}}
```

Following the deprecation link, I updated `open_im()` to instead use `conversations.open`.


In addition, when the bot is added to a group chat while running, it will not trigger a `_on_channel_created()`, so I added a RTM event listener for the `group_joined` and `mpim_joined` events.