### PR TITLE
Always respond to `@listen_to`-decorated plugins

### DIFF
--- a/machine/dispatch.py
+++ b/machine/dispatch.py
@@ -40,12 +40,12 @@ class EventDispatcher:
         # Handle message listeners
         event = payload['data']
         if 'user' in event and not event['user'] == self._get_bot_id():
+            listeners = self._find_listeners('listen_to')
             respond_to_msg = self._check_bot_mention(event)
             if respond_to_msg:
-                listeners = self._find_listeners('respond_to')
+                listeners += self._find_listeners('respond_to')
                 self._dispatch_listeners(listeners, respond_to_msg)
             else:
-                listeners = self._find_listeners('listen_to')
                 self._dispatch_listeners(listeners, event)
 
     def _find_listeners(self, _type):


### PR DESCRIPTION
Add a new `listen_or_respond_to` decorator that allows plugins to process messages when sent publicly (with or without addressing the bot) _or_ via private message.

For example, the default `PingPongPlugin` uses `listen_to`, so there is no way to send a **ping** privately to the bot and get a reply. The default `HelloPlugin` uses `respond_to`, so you saying **hi** to the bot in a private message returns a response, but publicly, it requires addressing the bot to get a response.

This new decorator allows a hybrid of the two, so the same regex can be used to trigger a response via private message *or* in public, without addressing the bot. This avoids having to use both the `listen_to` and `respond_to` decorators, which requires duplicating the regex, and avoids double-entries in the `HelpPlugin`.

Closes #435.