### PR TITLE
Make channel topic creator optional

### DIFF
--- a/machine/models/channel.py
+++ b/machine/models/channel.py
@@ -7,7 +7,7 @@ from dacite import from_dict
 @dataclass(frozen=True)
 class PurposeTopic:
     value: str
-    creator: str
+    creator: Optional[str]
     last_set: int
 
 


### PR DESCRIPTION
Slack API on occasion returns None for this field. Fixes https://github.com/DandyDev/slack-machine/issues/397.