### PR TITLE
Only cover named channels when attempting to find a channel by name

### DIFF
--- a/machine/plugins/base.py
+++ b/machine/plugins/base.py
@@ -68,10 +68,15 @@ class MachineBasePlugin:
         return self._client.channels
 
     def find_channel_by_name(self, channel_name: str) -> Optional[Channel]:
+        """Find a channel by its name, irrespective of a preceding pound symbol. This does not include DMs.
+
+        :param channel_name: The name of the channel to retrieve.
+        :return: The channel if found, None otherwise.
+        """
         if channel_name.startswith('#'):
             channel_name = channel_name[1:]
         for c in self.channels.values():
-            if channel_name.lower() == c.name_normalized.lower():
+            if c.name_normalized and channel_name.lower() == c.name_normalized.lower():
                 return c
 
     @property


### PR DESCRIPTION
When attempting to fetch a channel by name, I'm encountering the following error:

```
[ERROR] slack.rtm.client client.py:_dispatch_event:506 | When calling '#handle_message()' in the 'machine.dispatch' module the following error was raised: 'NoneType' object has no attribute 'lower'
```

After stepping through with a debugger, I found that this is triggered by my use of `find_channel_by_name`.  While looping over all available channels, it encounters a DM:

```
Channel(id='REDACTED', name=None, is_channel=None, created=1625189369, creator=None, is_archived=False, is_general=None, name_normalized=None, is_shared=None, is_org_shared=False, is_member=None, is_private=None, is_mpim=None, is_group=None, is_im=True, user='UREDACTED', members=None, topic=None, purpose=None, previous_names=None)
```

... and fails because `name_normalized` is `None`.  By updating the test to only occur if `name_normalized` is defined, we can ensure only named objects are targeted by `find_channel_by_name`.