### PR TITLE
[WIP] Populate a channel members list

### DIFF
--- a/machine/models/channel.py
+++ b/machine/models/channel.py
@@ -32,7 +32,6 @@ class Channel:
     is_group: Optional[bool]
     is_im: Optional[bool]
     user: Optional[str]
-    num_members: Optional[int]
     topic: Optional[PurposeTopic]
     purpose: Optional[PurposeTopic]
     previous_names: Optional[List[str]]
@@ -48,8 +47,6 @@ class Channel:
     @property
     def members(self) -> Optional[List[str]]:
         """Get the member IDs for the given users."""
-        if not self.num_members:
-            return None
         if not self._members:
             self._load_members()
         return self._members
@@ -64,7 +61,6 @@ class Channel:
         self._members.clear()
         for member in all_members:
             self._members.append(member)
-
 
     @staticmethod
     def from_api_response(user_reponse: Dict[str, Any]) -> 'Channel':

--- a/machine/models/channel.py
+++ b/machine/models/channel.py
@@ -1,8 +1,7 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import List, Dict, Any, Optional
 
 from dacite import from_dict
-
 
 @dataclass(frozen=True)
 class PurposeTopic:
@@ -33,10 +32,11 @@ class Channel:
     is_group: Optional[bool]
     is_im: Optional[bool]
     user: Optional[str]
-    members: Optional[List[str]]
+    num_members: Optional[int]
     topic: Optional[PurposeTopic]
     purpose: Optional[PurposeTopic]
     previous_names: Optional[List[str]]
+    _members: List[str] = field(default_factory=list)
 
     @property
     def identifier(self):
@@ -44,6 +44,27 @@ class Channel:
             return self.name
         else:
             return self.id
+
+    @property
+    def members(self) -> Optional[List[str]]:
+        """Get the member IDs for the given users."""
+        if not self.num_members:
+            return None
+        if not self._members:
+            self._load_members()
+        return self._members
+
+    def _load_members(self):
+        """Load a fresh set of members."""
+        from machine.clients.singletons.slack import LowLevelSlackClient, call_paginated_endpoint
+        web_client = LowLevelSlackClient.get_instance().web_client
+        all_members = call_paginated_endpoint(
+            web_client.conversations_members, 'members', channel=self.id
+        )
+        self._members.clear()
+        for member in all_members:
+            self._members.append(member)
+
 
     @staticmethod
     def from_api_response(user_reponse: Dict[str, Any]) -> 'Channel':


### PR DESCRIPTION
Slack's `conversations_list` endpoint does not return a members collection. However, one is modeled on the Channel dataclass.  I need to get the channel members for a plugin I'm working on, so here's a starting attempt at making this happen.

1. the `channels_list` endpoint provides us a `num_members` attribute, which we can store
2. on attempted `members` access, if there are members in the room, lazily load them.

I pushed this out to start a discussion - there are obviously shortcomings around the caching behavior. Specifically, it'll never get refreshed.  Some options I see:

1. Expose this to the end user in the form of a `fetch_members()` function, and perhaps a `last_members` attribute so folks know the freshness of their data.
2. Don't cache at all.
3. Listen to all channels for join/leave updates and invalidate the caches.
4. Create a standalone function for loading channel members on demand, and don't store members on the Channel object.
5. Something else.

Let me know what aligns with your vision for `slack-machine`. I don't mind iterating on this.  Thanks for the framework :-)